### PR TITLE
updates to address changes in how hugo will handle the following:

### DIFF
--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -23,7 +23,7 @@
         "@context": "http://schema.org",
         "@type": "WebSite",
         "url": "{{ .Permalink }}",
-        {{- with .Site.LanguageCode -}}
+        {{- with .Site.Language.Locale -}}
             "inLanguage": "{{ . }}",
         {{- end -}}
         {{- with .Site.Params.Author.name -}}
@@ -69,7 +69,7 @@
         "@context": "http://schema.org",
         "@type": "BlogPosting",
         "headline": {{ .Title | safeHTML }},
-        "inLanguage": "{{ .Site.LanguageCode }}",
+        "inLanguage": "{{ .Site.Language.Locale }}",
         "mainEntityOfPage": {
             "@type": "WebPage",
             "@id": "{{ .Permalink }}"

--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -63,7 +63,7 @@
                     <select class="language-select" id="language-select-desktop" onchange="location = this.value;">
                         {{- if eq .Kind "404" -}}
                             {{- /* https://github.com/dillonzq/LoveIt/issues/378 */ -}}
-                            {{- range .Sites -}}
+                            {{- range hugo.Sites -}}
                                 {{- $link := printf "%v/404.html" .LanguagePrefix -}}
                                 <option value="{{ $link }}"{{ if eq . $.Site }} selected{{ end }}>
                                     {{- .Language.LanguageName -}}
@@ -156,7 +156,7 @@
                     <select class="language-select" onchange="location = this.value;">
                         {{- if eq .Kind "404" -}}
                             {{- /* https://github.com/dillonzq/LoveIt/issues/378 */ -}}
-                            {{- range .Sites -}}
+                            {{- range hugo.Sites -}}
                                 {{- $link := printf "%v/404.html" .LanguagePrefix -}}
                                 <option value="{{ $link }}"{{ if eq . $.Site }} selected{{ end }}>
                                     {{- .Language.LanguageName -}}

--- a/layouts/_partials/init.html
+++ b/layouts/_partials/init.html
@@ -21,7 +21,7 @@
     {{- else if eq .Params.comment false -}}
         {{- .Scratch.Set "comment" dict -}}
     {{- end -}}
-{{- else if eq .Site .Sites.Default -}}
+{{- else if eq .Site hugo.Sites.Default -}}
     {{- warnf "Current environment is not \"production\". The \"comment system\", \"CDN\" and \"fingerprint\" will be disabled.\n" -}}
     {{- warnf "当前运行环境不是 \"production\". \"评论系统\", \"CDN\" 和 \"fingerprint\" 不会启用.\n" -}}
 {{- end -}}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,7 +1,7 @@
 {{- partial "init.html" . -}}
 
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -10,7 +10,7 @@
             {{- .Site.Params.description | default .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
-        {{- with .Site.LanguageCode -}}
+        {{- with .Site.Language.Locale -}}
             <language>
                 {{- . -}}
             </language>

--- a/layouts/posts/rss.xml
+++ b/layouts/posts/rss.xml
@@ -10,7 +10,7 @@
             {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} | {{ .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
-        {{- with .Site.LanguageCode -}}
+        {{- with .Site.Language.Locale -}}
             <language>
                 {{- . -}}
             </language>

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -10,7 +10,7 @@
             {{- .Title }} - {{ T .Data.Singular | default .Data.Singular }} - {{ .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
-        {{- with .Site.LanguageCode -}}
+        {{- with .Site.Language.Locale -}}
             <language>
                 {{- . -}}
             </language>


### PR DESCRIPTION
hugo is going to deprecate a few things.  this PR gets ahead of these a bit so that i can keep CI/CD modern.

```text
<html lang="{{ .Site.LanguageCode }}"> -> <html lang="{{ .Site.Language.Locale }}">
{{- range .Sites -}}                   -> {{- range hugo.Sites -}}
```